### PR TITLE
Write to a temporary file, and reload it un updates

### DIFF
--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -12,7 +12,5 @@
   (write-region (region-beginning) (region-end) grammarly-tempfile)
   (call-process-shell-command (concat grammarly-cmd " " grammarly-tempfile)))
 
-(global-set-key (kbd "C-c C-g") 'grammarly-save-region-and-run)
-
 (provide 'emacs-grammarly)
 ;;; emacs-grammarly.el ends here

--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -3,26 +3,24 @@
 ;;   URL: http://example.com/jrhacker/superfrobnicate
 ;;; Code:
 
-(defvar grammarly-default-file nil
-  "If non-nil, `grammarly-save-region-and-run' always writes to this file.")
-
-(defvar-local grammarly-buffer-file nil
-  "The temporary file associated with the current buffer.")
+(defvar grammarly-file nil
+  "The temporary file for storing things sent to Grammarly.")
 
 (defvar grammarly-cmd "open -a Grammarly")
+
 (defvar grammarly-reload-cmd "osascript <<END
 tell application \"Grammarly\" to activate
 tell application \"System Events\"
-	keystroke \"r\" using command down
+        keystroke \"r\" using command down
 end tell
 END")
 
 (defun grammarly-save-region-and-run ()
   "Save region to a tempfile and run Grammarly on it."
   (interactive)
-  (let ((file (or grammarly-default-file grammarly-buffer-file
-                  (setq grammarly-buffer-file
-                        (make-temp-file (buffer-name) nil ".txt")))))
+  (let ((file (or grammarly-file
+                  (setq grammarly-file
+                        (make-temp-file "grammarly" nil ".txt")))))
     (write-region (region-beginning) (region-end) file)
     (call-process-shell-command
      (concat grammarly-cmd " " file ";" grammarly-reload-cmd))))

--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -10,6 +10,12 @@
   "The temporary file associated with the current buffer.")
 
 (defvar grammarly-cmd "open -a Grammarly")
+(defvar grammarly-reload-cmd "osascript <<END
+tell application \"Grammarly\" to activate
+tell application \"System Events\"
+	keystroke \"r\" using command down
+end tell
+END")
 
 (defun grammarly-save-region-and-run ()
   "Save region to a tempfile and run Grammarly on it."
@@ -18,7 +24,8 @@
                   (setq grammarly-buffer-file
                         (make-temp-file (buffer-name) nil ".txt")))))
     (write-region (region-beginning) (region-end) file)
-    (call-process-shell-command (concat grammarly-cmd " " file))))
+    (call-process-shell-command
+     (concat grammarly-cmd " " file ";" grammarly-reload-cmd))))
 
 (provide 'emacs-grammarly)
 ;;; emacs-grammarly.el ends here

--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -10,14 +10,9 @@
   "Save region to a tempfile and run Grammarly on it."
   (interactive)
   (write-region (region-beginning) (region-end) grammarly-tempfile)
-  (call-process-shell-command (concat grammarly-cmd " " grammarly-tempfile))
-  ;(kill-region (region-beginning) (region-end))
-  ;(insert "<<here>>\n")
-  ;(insert-file-contents tempfile)
-  )
+  (call-process-shell-command (concat grammarly-cmd " " grammarly-tempfile)))
 
 (global-set-key (kbd "C-c C-g") 'grammarly-save-region-and-run)
-
 
 (provide 'emacs-grammarly)
 ;;; emacs-grammarly.el ends here

--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -18,10 +18,12 @@ END")
 (defun grammarly-save-region-and-run ()
   "Save region to a tempfile and run Grammarly on it."
   (interactive)
-  (let ((file (or grammarly-file
+  (let ((beg (if (region-active-p) (region-beginning) (point-min)))
+        (end (if (region-active-p) (region-end) (point-max)))
+        (file (or grammarly-file
                   (setq grammarly-file
                         (make-temp-file "grammarly" nil ".txt")))))
-    (write-region (region-beginning) (region-end) file)
+    (write-region beg end file)
     (call-process-shell-command
      (concat grammarly-cmd " " file ";" grammarly-reload-cmd))))
 

--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -3,14 +3,22 @@
 ;;   URL: http://example.com/jrhacker/superfrobnicate
 ;;; Code:
 
-(defvar grammarly-tempfile "/home/magnus/Desktop/Grammarly.txt")
+(defvar grammarly-default-file nil
+  "If non-nil, `grammarly-save-region-and-run' always writes to this file.")
+
+(defvar-local grammarly-buffer-file nil
+  "The temporary file associated with the current buffer.")
+
 (defvar grammarly-cmd "open -a Grammarly")
 
 (defun grammarly-save-region-and-run ()
   "Save region to a tempfile and run Grammarly on it."
   (interactive)
-  (write-region (region-beginning) (region-end) grammarly-tempfile)
-  (call-process-shell-command (concat grammarly-cmd " " grammarly-tempfile)))
+  (let ((file (or grammarly-default-file grammarly-buffer-file
+                  (setq grammarly-buffer-file
+                        (make-temp-file (buffer-name) nil ".txt")))))
+    (write-region (region-beginning) (region-end) file)
+    (call-process-shell-command (concat grammarly-cmd " " file))))
 
 (provide 'emacs-grammarly)
 ;;; emacs-grammarly.el ends here

--- a/emacs-grammarly.el
+++ b/emacs-grammarly.el
@@ -15,6 +15,13 @@ tell application \"System Events\"
 end tell
 END")
 
+(defvar grammarly-do-unfill-paragraph t
+  "If non-nil, remove newlines in paragraphs before sending it to Grammarly.")
+
+(defun grammarly-unfill-paragraph ()
+  (let ((fill-column most-positive-fixnum))
+    (fill-region (point-min) (point-max))))
+
 (defun grammarly-save-region-and-run ()
   "Save region to a tempfile and run Grammarly on it."
   (interactive)
@@ -23,7 +30,10 @@ END")
         (file (or grammarly-file
                   (setq grammarly-file
                         (make-temp-file "grammarly" nil ".txt")))))
-    (write-region beg end file)
+    (let ((buf (current-buffer)))
+      (with-temp-file file
+        (insert-buffer-substring buf beg end)
+        (when grammarly-do-unfill-paragraph (grammarly-unfill-paragraph))))
     (call-process-shell-command
      (concat grammarly-cmd " " file ";" grammarly-reload-cmd))))
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-emacs-grammarly.el --- simple plugin to send a text to Grammarly  
+emacs-grammarly.el --- simple plugin to send a text to Grammarly
 ===================================================================================
 
 ![](docs/demo.gif)
@@ -25,5 +25,9 @@ Change the variables in the `emacs-grammarly.el` file, so it would work for you:
 
     (defvar grammarly-tempfile "/home/magnus/Desktop/Grammarly.txt")
     (defvar grammarly-cmd "open -a Grammarly")
+
+Bind the `grammarly-save-region-and-run` to a key, for instance:
+
+    (global-set-key (kbd "C-c C-g") 'grammarly-save-region-and-run)
 
 Change to your tempfile and change a way how you would run Grammarly from the terminal (this way works of OSX).


### PR DESCRIPTION
Hi!

These commits makes the following changes:
- Use a temporary file, instead of a user-specified file
- If no region is selected, send the entire buffer
- Automatic reloading in Grammarly when invoking `grammarly-save-region-and-run`

There is a major caveat: if Grammarly is open, and is not visiting the temporary file we create, then reloading doesn't work. I haven't found a solution to this yet, but I do think it offers a higher degree of automation than before.

The second caveat (which I'm pretty sure was present before my changes), is that Grammarly stores the old version of the file, so it leaves quite a bit of garbage.